### PR TITLE
Use cusparseSpSM_updateMatrix in CUSOLVERRF.jl

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.9']
-        cuda-version: ['11.8', '12.3']
+        cuda-version: ['11.8', '12.4']
         julia-arch: [x64]
         os: [ubuntu-22.04]
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ uuid = "a8cc9031-bad2-4722-94f5-40deabb4245c"
 version = "0.2.4"
 
 [compat]
-CUDA = "4, 5.1.1"
+CUDA = "4, 5.3.0"
 KLU = "0.3, 0.4"
 julia = "1.6"
 

--- a/src/backsolve.jl
+++ b/src/backsolve.jl
@@ -118,8 +118,8 @@ function CuSparseSM(
 ) where T
     chktrans(transa)
 
-    # CUDA 12.3 is required for the routine cusparseSpSV_updateMatrix
-    @assert CUDA.runtime_version() ≥ v"12.3"
+    # CUDA 12.4 is required for the routine cusparseSpSM_updateMatrix
+    @assert CUDA.runtime_version() ≥ v"12.4"
 
     m, n = size(A)
     @assert m == n
@@ -173,8 +173,10 @@ function backsolve!(s::CuSparseSM, A::CUSPARSE.CuSparseMatrixCSR{T}, X::CuMatrix
     alpha = one(T)
 
     descX = CUSPARSE.CuDenseMatrixDescriptor(X)
-    transx = 'N'
+    CUSPARSE.cusparseSpSM_updateMatrix(CUSPARSE.handle(), s.infoL, A.nzVal, CUSPARSE.CUSPARSE_SPSM_UPDATE_GENERAL)
+    CUSPARSE.cusparseSpSM_updateMatrix(CUSPARSE.handle(), s.infoU, A.nzVal, CUSPARSE.CUSPARSE_SPSM_UPDATE_GENERAL)
 
+    transx = 'N'
     if s.transa == 'N'
         CUSPARSE.cusparseSpSM_solve(
             CUSPARSE.handle(), s.transa, transx, Ref{T}(alpha), s.descL, descX, descX, T, s.algo, s.infoL,


### PR DESCRIPTION
- Update CUSOLVERRF.jl to use `cusparseSpSM_updateMatrix` and avoid the computation of the analysis each time that we update the sparse matrix.

```julia
     Testing Running tests...
CUDA runtime 12.4, artifact installation
CUDA driver 12.4
NVIDIA driver 550.54.15

CUDA libraries: 
- CUBLAS: 12.4.2
- CURAND: 10.3.5
- CUFFT: 11.2.0
- CUSOLVER: 11.6.0
- CUSPARSE: 12.3.0
- CUPTI: 22.0.0
- NVML: 12.0.0+550.54.15

Julia packages: 
- CUDA: 5.3.0
- CUDA_Driver_jll: 0.8.0+0
- CUDA_Runtime_jll: 0.12.0+1

Toolchain:
- Julia: 1.10.2
- LLVM: 15.0.7

8 devices:
  0: NVIDIA A100 80GB PCIe (sm_80, 79.135 GiB / 80.000 GiB available)
  1: NVIDIA A100 80GB PCIe (sm_80, 79.135 GiB / 80.000 GiB available)
  2: NVIDIA A100 80GB PCIe (sm_80, 79.135 GiB / 80.000 GiB available)
  3: NVIDIA A100 80GB PCIe (sm_80, 79.135 GiB / 80.000 GiB available)
  4: NVIDIA A100-PCIE-40GB (sm_80, 39.378 GiB / 40.000 GiB available)
  5: NVIDIA A100-PCIE-40GB (sm_80, 39.378 GiB / 40.000 GiB available)
  6: NVIDIA A100-PCIE-40GB (sm_80, 39.378 GiB / 40.000 GiB available)
  7: NVIDIA A100-PCIE-40GB (sm_80, 39.378 GiB / 40.000 GiB available)
Test Summary: | Pass  Total   Time
cusolverRF    |    2      2  16.8s
Test Summary:     | Pass  Total  Time
GLU factorization |    2      2  1.4s
Test Summary:              | Pass  Total  Time
KLU symbolic factorization |    2      2  0.2s
Test Summary:                | Pass  Total  Time
Interface with LinearAlgebra |   16     16  3.6s
     Testing CUSOLVERRF tests passed
```